### PR TITLE
Count and limit 'sigchecks'

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -101,7 +101,7 @@ static bool IsOpcodeDisabled(opcodetype opcode, uint32_t flags) {
 
 bool EvalScript(std::vector<valtype> &stack, const CScript &script,
                 uint32_t flags, const BaseSignatureChecker &checker,
-                ScriptError *serror) {
+                ScriptError *serror, uint32_t *pnSigChecks) {
     static const CScriptNum bnZero(0);
     static const CScriptNum bnOne(1);
     static const valtype vchFalse(0);
@@ -898,6 +898,10 @@ bool EvalScript(std::vector<valtype> &stack, const CScript &script,
                             return set_error(serror, SCRIPT_ERR_SIG_NULLFAIL);
                         }
 
+                        if (fSuccess && pnSigChecks) {
+                            *pnSigChecks += 1;
+                        }
+
                         popstack(stack);
                         popstack(stack);
                         stack.push_back(fSuccess ? vchTrue : vchFalse);
@@ -946,6 +950,10 @@ bool EvalScript(std::vector<valtype> &stack, const CScript &script,
                             return set_error(serror, SCRIPT_ERR_SIG_NULLFAIL);
                         }
 
+                        if (fSuccess && pnSigChecks) {
+                            *pnSigChecks += 1;
+                        }
+
                         popstack(stack);
                         popstack(stack);
                         popstack(stack);
@@ -977,6 +985,7 @@ bool EvalScript(std::vector<valtype> &stack, const CScript &script,
                             nKeysCount > MAX_PUBKEYS_PER_MULTISIG) {
                             return set_error(serror, SCRIPT_ERR_PUBKEY_COUNT);
                         }
+                        const int origN = nKeysCount;
                         nOpCount += nKeysCount;
                         if (nOpCount > MAX_OPS_PER_SCRIPT) {
                             return set_error(serror, SCRIPT_ERR_OP_COUNT);
@@ -1081,6 +1090,11 @@ bool EvalScript(std::vector<valtype> &stack, const CScript &script,
                             return set_error(serror, SCRIPT_ERR_SIG_NULLDUMMY);
                         }
                         popstack(stack);
+
+                        if (fSuccess && pnSigChecks) {
+                            // Use original nKeysCount
+                            *pnSigChecks += origN;
+                        }
 
                         stack.push_back(fSuccess ? vchTrue : vchFalse);
 

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -88,7 +88,7 @@ public:
 
 bool EvalScript(std::vector<std::vector<uint8_t>> &stack, const CScript &script,
                 uint32_t flags, const BaseSignatureChecker &checker,
-                ScriptError *error = nullptr);
+                ScriptError *error = nullptr, uint32_t *pnSigChecks = nullptr);
 bool VerifyScript(const CScript &scriptSig, const CScript &scriptPubKey,
                   uint32_t flags, const BaseSignatureChecker &checker,
                   ScriptError *serror = nullptr);

--- a/src/script/script_error.cpp
+++ b/src/script/script_error.cpp
@@ -92,6 +92,8 @@ const char *ScriptErrorString(const ScriptError serror) {
             return "Script did not clean its stack";
         case SCRIPT_ERR_NONCOMPRESSED_PUBKEY:
             return "Using non-compressed public key";
+        case SCRIPT_ERR_SIGCHECKS_LIMIT:
+            return "Too many sigchecks";
         case SCRIPT_ERR_ILLEGAL_FORKID:
             return "Illegal use of SIGHASH_FORKID";
         case SCRIPT_ERR_MUST_USE_FORKID:

--- a/src/script/script_error.h
+++ b/src/script/script_error.h
@@ -69,6 +69,7 @@ typedef enum ScriptError_t {
 
     /* misc */
     SCRIPT_ERR_NONCOMPRESSED_PUBKEY,
+    SCRIPT_ERR_SIGCHECKS_LIMIT,
 
     /* anti replay */
     SCRIPT_ERR_ILLEGAL_FORKID,

--- a/src/script/script_flags.h
+++ b/src/script/script_flags.h
@@ -111,6 +111,10 @@ enum {
     // The exception to CLEANSTACK and P2SH for the recovery of coins sent
     // to p2sh segwit addresses is not allowed.
     SCRIPT_DISALLOW_SEGWIT_RECOVERY = (1U << 20),
+
+    // Whether to limit the number of 'sigchecks' that occur during script
+    // execution to at most 2 + (scriptsig_length / 45).
+    SCRIPT_VERIFY_SIGCHECKS_LIMIT = (1U << 21),
 };
 
 #endif // BITCOIN_SCRIPT_SCRIPTFLAGS_H


### PR DESCRIPTION
(self PR just for discussion purposes)

Motivation: The sigops limit sucks and we ought to have something based on actual signature check operations. I call them "sigchecks" (signature checks) to distinguish from "sigops" (signature opcodes).

## Counting mechanism

- +1 sigcheck for successful checksig / checkdatasig.
- +N sigchecks for successful checkmultisig M-of-N. This is the upper
limit for the legacy mechanism that needs to do up to N checks. The new
schnorr checkmultisig will count as +M sigchecks on success.
- Why count N and not the actual number of ECC operations performed?
We want to in principle be able to count sigchecks without having to
perform any ECC math, so legacy checkmultisig counts as just N even if
fewer signature checking operations actually occur.
- Why only count successes? Now we have NULLFAIL rule, so
failed check*sig will consume no resources and we want to design around
this simple idea, even if some historical txns did violate NULLFAIL.

## Limiting mechanism

Because of the script validity cache, it is a pain in the ass to introduce
a limit on sigchecks that applies per-transaction or per-block. However
it is very easy (and natural) to apply a limit per-input!

We allow **a free allowance of 2 sigchecks, plus an additional 1 sigcheck
for every 45 bytes of scriptSig length**. Note that the total length of an input
is equal to 40 + len(scriptSig) + len(varint), where len(varint) is
typically 1 or 2 bytes. Thus, the maximal density of sigchecks in a
transaction or block is 1 per 20.5 bytes, only possible using nonstandard
techniques.

The limit is designed to allow the two most-dense standard cases:
- spending bare multisig 1-of-3 in legacy mode (3 sigchecks and 72 byte scriptsig)
- spending p2sh-multisig 1-of-15 in legacy mode (15 sigchecks and 588 byte scriptsig)

Once Schnorr multisig (with its lower sigchecks) becomes popular, the
limit can be tightened considerably.

## Research

A full search of BCH blockchain up to height 585795 shows only three old transaction that have violated this limit:
* Block#292165: 18f4c7059be729fb48d014d2a4a0658a8ba1d35798d42274691a117da91643b5 -- has 145 byte scriptsig with 16 sigchecks
* Block#297775: ed2f95d248d37367aaef3040c123a12af04a86f05f78ccd45871fba4acb4bb65 -- has 90 byte scriptsig with 16 sigchecks
* Block #311706: 892bb6f09ed2ad140c48703aa71f1830273afb50c3c68f0d92d26045df47d15a -- has 148 byte scriptsig with 9 sigchecks.

All 675069516 spends are shown on the graph below, except 8539 that go off the top of the plot:

![plot2d](https://user-images.githubusercontent.com/36528214/59152099-79333200-89f2-11e9-9495-912776c1b7f6.png)
