### PR TITLE
Newmultisig bitfield alt

### DIFF
--- a/src/script/script.h
+++ b/src/script/script.h
@@ -339,6 +339,12 @@ public:
         return *this;
     }
 
+    inline CScriptNum &operator>>=(const int64_t &rhs) {
+        assert(rhs >= 0 && m_value >= 0 && rhs < 64);
+        m_value >>= rhs;
+        return *this;
+    }
+
     int getint() const {
         if (m_value > std::numeric_limits<int>::max())
             return std::numeric_limits<int>::max();

--- a/src/script/script_flags.h
+++ b/src/script/script_flags.h
@@ -111,6 +111,11 @@ enum {
     // The exception to CLEANSTACK and P2SH for the recovery of coins sent
     // to p2sh segwit addresses is not allowed.
     SCRIPT_DISALLOW_SEGWIT_RECOVERY = (1U << 20),
+
+    // Whether to allow new multisig logic to trigger. (new multisig logic
+    // requires stricter limits on public keys, verifies faster, and only
+    // allows null or schnorr signatures)
+    SCRIPT_ENABLE_NEW_MULTISIG = (1U << 21),
 };
 
 #endif // BITCOIN_SCRIPT_SCRIPTFLAGS_H

--- a/src/script/sigencoding.cpp
+++ b/src/script/sigencoding.cpp
@@ -174,6 +174,14 @@ static bool CheckRawECDSASignatureEncoding(const slicedvaltype &sig,
     return true;
 }
 
+static bool CheckRawSchnorrSignatureEncoding(const slicedvaltype &sig,
+                                             uint32_t flags,
+                                             ScriptError *serror) {
+    // In a generic-signature context, 64-byte signatures are interpreted
+    // as Schnorr signatures (always correctly encoded) when flag set.
+    return (sig.size() == 64);
+}
+
 static bool CheckRawSignatureEncoding(const slicedvaltype &sig, uint32_t flags,
                                       ScriptError *serror) {
     if ((flags & SCRIPT_ENABLE_SCHNORR) && (sig.size() == 64)) {
@@ -256,6 +264,18 @@ bool CheckTransactionECDSASignatureEncoding(const valtype &vchSig,
            ScriptError *templateSerror) {
             return CheckRawECDSASignatureEncoding(templateSig, templateFlags,
                                                   templateSerror);
+        });
+}
+
+bool CheckTransactionSchnorrSignatureEncoding(const valtype &vchSig,
+                                              uint32_t flags,
+                                              ScriptError *serror) {
+    return CheckTransactionSignatureEncodingImpl(
+        vchSig, flags, serror,
+        [](const slicedvaltype &templateSig, uint32_t templateFlags,
+           ScriptError *templateSerror) {
+            return CheckRawSchnorrSignatureEncoding(templateSig, templateFlags,
+                                                    templateSerror);
         });
 }
 

--- a/src/script/sigencoding.h
+++ b/src/script/sigencoding.h
@@ -45,12 +45,20 @@ bool CheckTransactionSignatureEncoding(const valtype &vchSig, uint32_t flags,
 
 /**
  * Check that the signature provided to authentify a transaction is properly
- * encoded ECDSA signature. Signatures passed to OP_CHECKMULTISIG and its verify
- * variant must be checked using this function.
+ * encoded ECDSA signature (or null). Signatures passed to OP_CHECKMULTISIG
+ * and its verify variant must be checked using this function.
  */
 bool CheckTransactionECDSASignatureEncoding(const valtype &vchSig,
                                             uint32_t flags,
                                             ScriptError *serror);
+/**
+ * Check that the signature provided to authentify a transaction is properly
+ * encoded Schnorr signature (or null). Signatures passed to the new-mode
+ * OP_CHECKMULTISIG and its verify variant must be checked using this function.
+ */
+bool CheckTransactionSchnorrSignatureEncoding(const valtype &vchSig,
+                                              uint32_t flags,
+                                              ScriptError *serror);
 
 /**
  * Check that a public key is encoded properly.


### PR DESCRIPTION
Alternative to #2

This allows garbage pubkeys in the new mode, but has a much simpler trigger (which effectively _incorporates_ nulldummy rule).